### PR TITLE
Inject for melodic fixed

### DIFF
--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -42,7 +42,7 @@ jobs:
           sudo curl https://raw.githubusercontent.com/smarc-project/rosinstall/master/rosdep/50-smarc-${{ matrix.distro }}.list -o /etc/ros/rosdep/sources.list.d/50-smarc.list  
           if [ ${{ matrix.distro }} == "melodic" ]; then
             sudo apt install -y python-bloom python-rosdep
-            pip2 install --user --no-input Inject==3.5.4
+            pip install --user --no-input Inject==3.5.4
           else
             sudo apt install -y python3-bloom python3-rosdep
           fi

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -42,6 +42,7 @@ jobs:
           sudo curl https://raw.githubusercontent.com/smarc-project/rosinstall/master/rosdep/50-smarc-${{ matrix.distro }}.list -o /etc/ros/rosdep/sources.list.d/50-smarc.list  
           if [ ${{ matrix.distro }} == "melodic" ]; then
             sudo apt install -y python-bloom python-rosdep
+            pip2 install --user --no-input Inject==3.5.4
           else
             sudo apt install -y python3-bloom python3-rosdep
           fi


### PR DESCRIPTION
Added manual inject version to melodic-only setup in release_all.yml
Noetic is fine with the latest inject but melodic needs a specific version, and there is no ros-friendly way of doing distro-specific python package installation with a specific version...